### PR TITLE
python-izes classes

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -16,7 +16,7 @@ import random
 # Third-party libraries
 import numpy as np
 
-class Network():
+class Network(object):
 
     def __init__(self, sizes):
         """The list ``sizes`` contains the number of neurons in the
@@ -32,7 +32,7 @@ class Network():
         self.num_layers = len(sizes)
         self.sizes = sizes
         self.biases = [np.random.randn(y, 1) for y in sizes[1:]]
-        self.weights = [np.random.randn(y, x) 
+        self.weights = [np.random.randn(y, x)
                         for x, y in zip(sizes[:-1], sizes[1:])]
 
     def feedforward(self, a):
@@ -77,9 +77,9 @@ class Network():
             delta_nabla_b, delta_nabla_w = self.backprop(x, y)
             nabla_b = [nb+dnb for nb, dnb in zip(nabla_b, delta_nabla_b)]
             nabla_w = [nw+dnw for nw, dnw in zip(nabla_w, delta_nabla_w)]
-        self.weights = [w-(eta/len(mini_batch))*nw 
+        self.weights = [w-(eta/len(mini_batch))*nw
                         for w, nw in zip(self.weights, nabla_w)]
-        self.biases = [b-(eta/len(mini_batch))*nb 
+        self.biases = [b-(eta/len(mini_batch))*nb
                        for b, nb in zip(self.biases, nabla_b)]
 
     def backprop(self, x, y):
@@ -122,14 +122,14 @@ class Network():
         network outputs the correct result. Note that the neural
         network's output is assumed to be the index of whichever
         neuron in the final layer has the highest activation."""
-        test_results = [(np.argmax(self.feedforward(x)), y) 
+        test_results = [(np.argmax(self.feedforward(x)), y)
                         for (x, y) in test_data]
         return sum(int(x == y) for (x, y) in test_results)
-        
+
     def cost_derivative(self, output_activations, y):
         """Return the vector of partial derivatives \partial C_x /
         \partial a for the output activations."""
-        return (output_activations-y) 
+        return (output_activations-y)
 
 #### Miscellaneous functions
 def sigmoid(z):

--- a/src/network2.py
+++ b/src/network2.py
@@ -23,7 +23,7 @@ import numpy as np
 
 #### Define the quadratic and cross-entropy cost functions
 
-class QuadraticCost:
+class QuadraticCost(object):
 
     @staticmethod
     def fn(a, y):
@@ -39,7 +39,7 @@ class QuadraticCost:
         return (a-y) * sigmoid_prime_vec(z)
 
 
-class CrossEntropyCost:
+class CrossEntropyCost(object):
 
     @staticmethod
     def fn(a, y):
@@ -65,7 +65,7 @@ class CrossEntropyCost:
 
 
 #### Main Network class
-class Network():
+class Network(object):
 
     def __init__(self, sizes, cost=CrossEntropyCost):
         """The list ``sizes`` contains the number of neurons in the respective
@@ -97,7 +97,7 @@ class Network():
 
         """
         self.biases = [np.random.randn(y, 1) for y in self.sizes[1:]]
-        self.weights = [np.random.randn(y, x)/np.sqrt(x) 
+        self.weights = [np.random.randn(y, x)/np.sqrt(x)
                         for x, y in zip(self.sizes[:-1], self.sizes[1:])]
 
     def large_weight_initializer(self):
@@ -117,7 +117,7 @@ class Network():
 
         """
         self.biases = [np.random.randn(y, 1) for y in self.sizes[1:]]
-        self.weights = [np.random.randn(y, x) 
+        self.weights = [np.random.randn(y, x)
                         for x, y in zip(self.sizes[:-1], self.sizes[1:])]
 
     def feedforward(self, a):
@@ -126,12 +126,12 @@ class Network():
             a = sigmoid_vec(np.dot(w, a)+b)
         return a
 
-    def SGD(self, training_data, epochs, mini_batch_size, eta, 
-            lmbda = 0.0, 
-            evaluation_data=None, 
+    def SGD(self, training_data, epochs, mini_batch_size, eta,
+            lmbda = 0.0,
+            evaluation_data=None,
             monitor_evaluation_cost=False,
             monitor_evaluation_accuracy=False,
-            monitor_training_cost=False, 
+            monitor_training_cost=False,
             monitor_training_accuracy=False):
         """Train the neural network using mini-batch stochastic gradient
         descent.  The ``training_data`` is a list of tuples ``(x, y)``
@@ -201,9 +201,9 @@ class Network():
             delta_nabla_b, delta_nabla_w = self.backprop(x, y)
             nabla_b = [nb+dnb for nb, dnb in zip(nabla_b, delta_nabla_b)]
             nabla_w = [nw+dnw for nw, dnw in zip(nabla_w, delta_nabla_w)]
-        self.weights = [(1-eta*(lmbda/n))*w-(eta/len(mini_batch))*nw 
+        self.weights = [(1-eta*(lmbda/n))*w-(eta/len(mini_batch))*nw
                         for w, nw in zip(self.weights, nabla_w)]
-        self.biases = [b-(eta/len(mini_batch))*nb 
+        self.biases = [b-(eta/len(mini_batch))*nb
                        for b, nb in zip(self.biases, nabla_b)]
 
     def backprop(self, x, y):
@@ -244,7 +244,7 @@ class Network():
         """Return the number of inputs in ``data`` for which the neural
         network outputs the correct result. The neural network's
         output is assumed to be the index of whichever neuron in the
-        final layer has the highest activation.  
+        final layer has the highest activation.
 
         The flag ``convert`` should be set to False if the data set is
         validation or test data (the usual case), and to True if the
@@ -264,7 +264,7 @@ class Network():
 
         """
         if convert:
-            results = [(np.argmax(self.feedforward(x)), np.argmax(y)) 
+            results = [(np.argmax(self.feedforward(x)), np.argmax(y))
                        for (x, y) in data]
         else:
             results = [(np.argmax(self.feedforward(x)), y)

--- a/src/network3.py
+++ b/src/network3.py
@@ -78,8 +78,8 @@ def load_data_shared(filename="../data/mnist.pkl.gz"):
     return [shared(training_data), shared(validation_data), shared(test_data)]
 
 #### Main class used to construct and train networks
-class Network():
-    
+class Network(object):
+
     def __init__(self, layers, mini_batch_size):
         """Takes a list of `layers`, describing the network architecture, and
         a value for the `mini_batch_size` to be used during training
@@ -89,7 +89,7 @@ class Network():
         self.layers = layers
         self.mini_batch_size = mini_batch_size
         self.params = [param for layer in self.layers for param in layer.params]
-        self.x = T.matrix("x")  
+        self.x = T.matrix("x")
         self.y = T.ivector("y")
         init_layer = self.layers[0]
         init_layer.set_inpt(self.x, self.x, self.mini_batch_size)
@@ -100,7 +100,7 @@ class Network():
         self.output = self.layers[-1].output
         self.output_dropout = self.layers[-1].output_dropout
 
-    def SGD(self, training_data, epochs, mini_batch_size, eta, 
+    def SGD(self, training_data, epochs, mini_batch_size, eta,
             validation_data, test_data, lmbda=0.0):
         """Train the network using mini-batch stochastic gradient descent."""
         training_x, training_y = training_data
@@ -117,7 +117,7 @@ class Network():
         cost = self.layers[-1].cost(self)+\
                0.5*lmbda*l2_norm_squared/num_training_batches
         grads = T.grad(cost, self.params)
-        updates = [(param, param-eta*grad) 
+        updates = [(param, param-eta*grad)
                    for param, grad in zip(self.params, grads)]
 
         # define functions to train a mini-batch, and to compute the
@@ -128,29 +128,29 @@ class Network():
             givens={
                 self.x:
                 training_x[i*self.mini_batch_size: (i+1)*self.mini_batch_size],
-                self.y: 
+                self.y:
                 training_y[i*self.mini_batch_size: (i+1)*self.mini_batch_size]
             })
         validate_mb_accuracy = theano.function(
             [i], self.layers[-1].accuracy(self.y),
             givens={
-                self.x: 
+                self.x:
                 validation_x[i*self.mini_batch_size: (i+1)*self.mini_batch_size],
-                self.y: 
+                self.y:
                 validation_y[i*self.mini_batch_size: (i+1)*self.mini_batch_size]
             })
         test_mb_accuracy = theano.function(
             [i], self.layers[-1].accuracy(self.y),
             givens={
-                self.x: 
+                self.x:
                 test_x[i*self.mini_batch_size: (i+1)*self.mini_batch_size],
-                self.y: 
+                self.y:
                 test_y[i*self.mini_batch_size: (i+1)*self.mini_batch_size]
             })
         self.test_mb_predictions = theano.function(
             [i], self.layers[-1].y_out,
             givens={
-                self.x: 
+                self.x:
                 test_x[i*self.mini_batch_size: (i+1)*self.mini_batch_size]
             })
         # Do the actual training
@@ -158,7 +158,7 @@ class Network():
         for epoch in xrange(epochs):
             for minibatch_index in xrange(num_training_batches):
                 iteration = num_training_batches*epoch+minibatch_index
-                if iteration % 1000 == 0: 
+                if iteration % 1000 == 0:
                     print("Training mini-batch number {0}".format(iteration))
                 cost_ij = train_mb(minibatch_index)
                 if (iteration+1) % num_training_batches == 0:
@@ -182,7 +182,7 @@ class Network():
 
 #### Define layer types
 
-class ConvPoolLayer():
+class ConvPoolLayer(object):
     """Used to create a combination of a convolutional and a max-pooling
     layer.  A more sophisticated implementation would separate the
     two, but for our purposes we'll always use them together, and it
@@ -190,10 +190,10 @@ class ConvPoolLayer():
 
     """
 
-    def __init__(self, filter_shape, image_shape, poolsize=(2, 2), 
+    def __init__(self, filter_shape, image_shape, poolsize=(2, 2),
                  activation_fn=sigmoid):
         """`filter_shape` is a tuple of length 4, whose entries are the number
-        of filters, the number of input feature maps, the filter height, and the 
+        of filters, the number of input feature maps, the filter height, and the
         filter width.
 
         `image_shape` is a tuple of length 4, whose entries are the
@@ -233,7 +233,7 @@ class ConvPoolLayer():
             pooled_out + self.b.dimshuffle('x', 0, 'x', 'x'))
         self.output_dropout = self.output # no dropout in the convolutional layers
 
-class FullyConnectedLayer():
+class FullyConnectedLayer(object):
 
     def __init__(self, n_in, n_out, activation_fn=sigmoid, p_dropout=0.0):
         self.n_in = n_in
@@ -267,7 +267,7 @@ class FullyConnectedLayer():
         "Return the accuracy for the mini-batch."
         return T.mean(T.eq(y, self.y_out))
 
-class SoftmaxLayer():
+class SoftmaxLayer(object):
 
     def __init__(self, n_in, n_out, p_dropout=0.0):
         self.n_in = n_in

--- a/src/old/perceptron_learning.py
+++ b/src/old/perceptron_learning.py
@@ -9,7 +9,7 @@ perceptron learning algorithm."""
 # Third-party library
 import numpy as np
 
-class Perceptron():
+class Perceptron(object):
     """ A Perceptron instance can take a function and attempt to
     ``learn`` a bias and set of weights that compute that function,
     using the perceptron learning algorithm."""
@@ -26,7 +26,7 @@ class Perceptron():
         # inputs it is: [np.array([0, 0, 0]), np.array([0, 0, 1]), ...]
         self.inputs = [np.array([int(y)
                         for y in bin(x).lstrip("0b").zfill(num_inputs)])
-                       for x in xrange(2**num_inputs)]      
+                       for x in xrange(2**num_inputs)]
 
     def output(self, x):
         """ Return the output (0 or 1) from the perceptron, with input
@@ -37,12 +37,12 @@ class Perceptron():
         """ Find a bias and a set of weights for a perceptron that
         computes the function ``f``. ``eta`` is the learning rate, and
         should be a small positive number.  Does not terminate when
-        the function cannot be computed using a perceptron."""        
+        the function cannot be computed using a perceptron."""
         # initialize the bias and weights with random values
         self.bias = np.random.normal()
         self.weights = np.random.randn(self.num_inputs)
         number_of_errors = -1
-        while number_of_errors != 0:         
+        while number_of_errors != 0:
             number_of_errors = 0
             print "Beginning iteration"
             print "Bias: {:.3f}".format(self.bias)
@@ -56,11 +56,11 @@ class Perceptron():
                     self.weights = self.weights+eta*error*x
             print "Number of errors:", number_of_errors, "\n"
 
-def f(x): 
+def f(x):
     """ Target function for the perceptron learning algorithm.  I've
     chosen the NAND gate, but any function is okay, with the caveat
     that the algorithm won't terminate if ``f`` cannot be computed by
-    a perceptron."""    
+    a perceptron."""
     return int(not (x[0] and x[1]))
 
 if __name__ == "__main__":


### PR DESCRIPTION
While reading the code base, I noticed that you had lots of class declarations of the forms

    class Foo():
        ....

    class Foo:
        ....

My sense is that you're not planning on making any classes to be extensible via inheritance, but the more Pythonic way of doing this is to inherit the base object:

    class Foo(object):

This permits inheritance, which the old-style classes (eg, `class Foo:`) preclude. 

In the process, my editor, which aggressively trims trailing whitespace, discovered lots of this in your source files -- hence the larger-than-expected diff. I'm happy amend this commit to include only the class declaration changes and leave the whitespace alone if you're particular about these things. Lemme know. 
