### PR TITLE
Numpy's exp() is already vectorized, remove redundant vectorize() call.

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -38,7 +38,7 @@ class Network():
     def feedforward(self, a):
         """Return the output of the network if ``a`` is input."""
         for b, w in zip(self.biases, self.weights):
-            a = sigmoid_vec(np.dot(w, a)+b)
+            a = sigmoid(np.dot(w, a)+b)
         return a
 
     def SGD(self, training_data, epochs, mini_batch_size, eta,
@@ -96,11 +96,11 @@ class Network():
         for b, w in zip(self.biases, self.weights):
             z = np.dot(w, activation)+b
             zs.append(z)
-            activation = sigmoid_vec(z)
+            activation = sigmoid(z)
             activations.append(activation)
         # backward pass
         delta = self.cost_derivative(activations[-1], y) * \
-            sigmoid_prime_vec(zs[-1])
+            sigmoid_prime(zs[-1])
         nabla_b[-1] = delta
         nabla_w[-1] = np.dot(delta, activations[-2].transpose())
         # Note that the variable l in the loop below is used a little
@@ -111,7 +111,7 @@ class Network():
         # that Python can use negative indices in lists.
         for l in xrange(2, self.num_layers):
             z = zs[-l]
-            spv = sigmoid_prime_vec(z)
+            spv = sigmoid_prime(z)
             delta = np.dot(self.weights[-l+1].transpose(), delta) * spv
             nabla_b[-l] = delta
             nabla_w[-l] = np.dot(delta, activations[-l-1].transpose())
@@ -136,10 +136,6 @@ def sigmoid(z):
     """The sigmoid function."""
     return 1.0/(1.0+np.exp(-z))
 
-sigmoid_vec = np.vectorize(sigmoid)
-
 def sigmoid_prime(z):
     """Derivative of the sigmoid function."""
     return sigmoid(z)*(1-sigmoid(z))
-
-sigmoid_prime_vec = np.vectorize(sigmoid_prime)


### PR DESCRIPTION
No intended behavior change.  The vectorize() documentation points out
that vectorize() is not fast, and indeed after this change the time to
train one epoch is reduced from ~37.6s to ~10.5s on my laptop -- a 72%
reduction.

I haven't read more than Chapter 1 yet (in fact, I haven't completed Chapter 1),
so maybe something like this can be done in other places too.