### PR TITLE
Remove unused vector/matrix creation

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -87,8 +87,8 @@ class Network(object):
         gradient for the cost function C_x.  ``nabla_b`` and
         ``nabla_w`` are layer-by-layer lists of numpy arrays, similar
         to ``self.biases`` and ``self.weights``."""
-        nabla_b = [np.zeros(b.shape) for b in self.biases]
-        nabla_w = [np.zeros(w.shape) for w in self.weights]
+        nabla_b = [None] * len(self.biases)
+        nabla_w = [None] * len(self.weights)
         # feedforward
         activation = x
         activations = [x] # list to store all the activations, layer by layer

--- a/src/network2.py
+++ b/src/network2.py
@@ -211,8 +211,8 @@ class Network(object):
         gradient for the cost function C_x.  ``nabla_b`` and
         ``nabla_w`` are layer-by-layer lists of numpy arrays, similar
         to ``self.biases`` and ``self.weights``."""
-        nabla_b = [np.zeros(b.shape) for b in self.biases]
-        nabla_w = [np.zeros(w.shape) for w in self.weights]
+        nabla_b = [None] * len(self.biases)
+        nabla_w = [None] * len(self.weights)
         # feedforward
         activation = x
         activations = [x] # list to store all the activations, layer by layer


### PR DESCRIPTION
`nabla_b` and `nabla_w` are lists which store gradient,
but their initial values are not used.
So it isn't needed to call `np.zero` to create vector/matrix.