### PR TITLE
Outdated code updates

### DIFF
--- a/src/network3.py
+++ b/src/network3.py
@@ -36,7 +36,7 @@ import gzip
 import numpy as np
 import theano
 import theano.tensor as T
-from theano.tensor.nnet import conv
+from theano.tensor.nnet import conv2d
 from theano.tensor.nnet import softmax
 from theano.tensor import shared_randomstreams
 from theano.tensor.signal import pool
@@ -224,9 +224,8 @@ class ConvPoolLayer(object):
 
     def set_inpt(self, inpt, inpt_dropout, mini_batch_size):
         self.inpt = inpt.reshape(self.image_shape)
-        conv_out = conv.conv2d(
-            input=self.inpt, filters=self.w, filter_shape=self.filter_shape,
-            image_shape=self.image_shape)
+        conv_out = conv2d(
+            input=self.inpt, filters=self.w, filter_shape=self.filter_shape, input_shape = self.image_shape)
         pooled_out = pool.pool_2d(
             input=conv_out, ds=self.poolsize, ignore_border=True)
         self.output = self.activation_fn(

--- a/src/network3.py
+++ b/src/network3.py
@@ -160,7 +160,7 @@ class Network(object):
                 iteration = num_training_batches*epoch+minibatch_index
                 if iteration % 1000 == 0:
                     print("Training mini-batch number {0}".format(iteration))
-                cost_ij = train_mb(minibatch_index)
+                train_mb(minibatch_index)
                 if (iteration+1) % num_training_batches == 0:
                     validation_accuracy = np.mean(
                         [validate_mb_accuracy(j) for j in xrange(num_validation_batches)])


### PR DESCRIPTION
I've update some of the code that uses deprecated theano functions 
- Replaced theano.tensor.signal.downsample.max_pool_2d function with the newer theano.tensor.signal.pool.pool_2d function (Python throws a warning when using the earlier one)
- Replaced the deprecated theano.tensor.nnet.conv.conv2d with the newer Theano.tensor.nnet.conv2d function. Also, replaced the deprecated _image_shape_ parameter with _input_shape_ .

Also, removed the redundant _cost_ij_ variable in network3.py.
