### PR TITLE
Theano 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ has a repository for Python 3
 will not be updating the current repository for Python 3
 compatibility.
 
-The program `src/network3.py` uses version 0.6 or 0.7 of the Theano
-library.  It needs modification for compatibility with later versions
-of the library.  I will not be making such modifications.
+The program `src/network3.py` uses version 0.9 of the Theano library.
 
 As the code is written to accompany the book, I don't intend to add
 new features. However, bug reports are welcome, and you should feel

--- a/src/network3.py
+++ b/src/network3.py
@@ -41,7 +41,7 @@ import theano.tensor as T
 from theano.tensor.nnet import conv2d
 from theano.tensor.nnet import softmax
 from theano.tensor import shared_randomstreams
-from theano.tensor.signal import downsample
+from theano.tensor.signal import pool
 
 # Activation functions for neurons
 def linear(z): return z
@@ -229,7 +229,7 @@ class ConvPoolLayer(object):
         conv_out = conv2d(
             input=self.inpt, filters=self.w, filter_shape=self.filter_shape,
             image_shape=self.image_shape)
-        pooled_out = downsample.max_pool_2d(
+        pooled_out = pool.pool_2d(
             input=conv_out, ds=self.poolsize, ignore_border=True)
         self.output = self.activation_fn(
             pooled_out + self.b.dimshuffle('x', 0, 'x', 'x'))

--- a/src/network3.py
+++ b/src/network3.py
@@ -25,8 +25,7 @@ http://deeplearning.net/tutorial/lenet.html ), from Misha Denil's
 implementation of dropout (https://github.com/mdenil/dropout ), and
 from Chris Olah (http://colah.github.io ).
 
-Written for Theano 0.6 and 0.7, needs some changes for more recent
-versions of Theano.
+Written for Theano 0.9.
 
 """
 
@@ -39,7 +38,7 @@ import gzip
 import numpy as np
 import theano
 import theano.tensor as T
-from theano.tensor.nnet import conv
+from theano.tensor.nnet import conv2d
 from theano.tensor.nnet import softmax
 from theano.tensor import shared_randomstreams
 from theano.tensor.signal import downsample
@@ -227,7 +226,7 @@ class ConvPoolLayer(object):
 
     def set_inpt(self, inpt, inpt_dropout, mini_batch_size):
         self.inpt = inpt.reshape(self.image_shape)
-        conv_out = conv.conv2d(
+        conv_out = conv2d(
             input=self.inpt, filters=self.w, filter_shape=self.filter_shape,
             image_shape=self.image_shape)
         pooled_out = downsample.max_pool_2d(


### PR DESCRIPTION
These are the basic modifications needed for `network3.py` to be compatible with the latest Theano 0.9.0 (which `pip` will automatically install right now). Possibly a mention should also be added to the README about Theano moving towards a new GPU backend (more details at [http://deeplearning.net/software/theano/tutorial/using_gpu.html](url)).