### PR TITLE
network.py: Set cost_derivative as a static method.

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -126,7 +126,8 @@ class Network(object):
                         for (x, y) in test_data]
         return sum(int(x == y) for (x, y) in test_results)
 
-    def cost_derivative(self, output_activations, y):
+    @staticmethod
+    def cost_derivative(output_activations, y):
         """Return the vector of partial derivatives \partial C_x /
         \partial a for the output activations."""
         return (output_activations-y)


### PR DESCRIPTION
This method does not use any class member. So no need to use "self"
as a parameter. ==> Use of @staticmethod decorator.