### PR TITLE
Fixed output error calculation in network2.py

### DIFF
--- a/src/network2.py
+++ b/src/network2.py
@@ -223,7 +223,7 @@ class Network(object):
             activation = sigmoid(z)
             activations.append(activation)
         # backward pass
-        delta = (self.cost).delta(zs[-1], activations[-1], y)
+        delta = (self.cost).delta(zs[-1], activations[-1], y) * sigmoid_prime(zs[-1])
         nabla_b[-1] = delta
         nabla_w[-1] = np.dot(delta, activations[-2].transpose())
         # Note that the variable l in the loop below is used a little


### PR DESCRIPTION
Fixed delta of output by multiplying with sigmoid_prime, according to the eq. (BP1).