### PR TITLE
Pin requirements.txt to working set, including older theano.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
-scikit-learn
-scipy
-Theano
+numpy==1.13.3
+scikit-learn==0.19.0
+scipy==0.19.1
+Theano==0.7.0


### PR DESCRIPTION
I note there's a few closed issues complaining this doesn't work with the latest Theano module. I've thus pinned it to `0.7`, as well as the other libraries I've confirmed working.