### PR TITLE
Fix cost derivative

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -129,7 +129,7 @@ class Network(object):
     def cost_derivative(self, output_activations, y):
         """Return the vector of partial derivatives \partial C_x /
         \partial a for the output activations."""
-        return (output_activations-y)
+        return (output_activations-y) * 2
 
 #### Miscellaneous functions
 def sigmoid(z):


### PR DESCRIPTION
I assume I'm missing something, but if the cost function is (a-y)^2, wouldn't the derivative be 2*(a-y), instead of just (a-y)?