### PR TITLE
Remove source code trailing whitespaces

### DIFF
--- a/src/conv.py
+++ b/src/conv.py
@@ -33,52 +33,52 @@ def shallow(n=3, epochs=60):
             FullyConnectedLayer(n_in=784, n_out=100),
             SoftmaxLayer(n_in=100, n_out=10)], mini_batch_size)
         net.SGD(
-            training_data, epochs, mini_batch_size, 0.1, 
+            training_data, epochs, mini_batch_size, 0.1,
             validation_data, test_data)
         nets.append(net)
-    return nets 
+    return nets
 
 def basic_conv(n=3, epochs=60):
     for j in range(n):
         print "Conv + FC architecture"
         net = Network([
-            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                          filter_shape=(20, 1, 5, 5), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                          filter_shape=(20, 1, 5, 5),
                           poolsize=(2, 2)),
             FullyConnectedLayer(n_in=20*12*12, n_out=100),
             SoftmaxLayer(n_in=100, n_out=10)], mini_batch_size)
         net.SGD(
             training_data, epochs, mini_batch_size, 0.1, validation_data, test_data)
-    return net 
+    return net
 
 def omit_FC():
     for j in range(3):
         print "Conv only, no FC"
         net = Network([
-            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                          filter_shape=(20, 1, 5, 5), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                          filter_shape=(20, 1, 5, 5),
                           poolsize=(2, 2)),
             SoftmaxLayer(n_in=20*12*12, n_out=10)], mini_batch_size)
         net.SGD(training_data, 60, mini_batch_size, 0.1, validation_data, test_data)
-    return net 
+    return net
 
 def dbl_conv(activation_fn=sigmoid):
     for j in range(3):
         print "Conv + Conv + FC architecture"
         net = Network([
-            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                          filter_shape=(20, 1, 5, 5), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                          filter_shape=(20, 1, 5, 5),
                           poolsize=(2, 2),
                           activation_fn=activation_fn),
-            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12), 
-                          filter_shape=(40, 20, 5, 5), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12),
+                          filter_shape=(40, 20, 5, 5),
                           poolsize=(2, 2),
                           activation_fn=activation_fn),
             FullyConnectedLayer(
                 n_in=40*4*4, n_out=100, activation_fn=activation_fn),
             SoftmaxLayer(n_in=100, n_out=10)], mini_batch_size)
         net.SGD(training_data, 60, mini_batch_size, 0.1, validation_data, test_data)
-    return net 
+    return net
 
 # The following experiment was eventually omitted from the chapter,
 # but I've left it in here, since it's an important negative result:
@@ -90,11 +90,11 @@ def regularized_dbl_conv():
         for j in range(3):
             print "Conv + Conv + FC num %s, with regularization %s" % (j, lmbda)
             net = Network([
-                ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                              filter_shape=(20, 1, 5, 5), 
+                ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                              filter_shape=(20, 1, 5, 5),
                               poolsize=(2, 2)),
-                ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12), 
-                              filter_shape=(40, 20, 5, 5), 
+                ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12),
+                              filter_shape=(40, 20, 5, 5),
                               poolsize=(2, 2)),
                 FullyConnectedLayer(n_in=40*4*4, n_out=100),
                 SoftmaxLayer(n_in=100, n_out=10)], mini_batch_size)
@@ -105,13 +105,13 @@ def dbl_conv_relu():
         for j in range(3):
             print "Conv + Conv + FC num %s, relu, with regularization %s" % (j, lmbda)
             net = Network([
-                ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                              filter_shape=(20, 1, 5, 5), 
-                              poolsize=(2, 2), 
+                ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                              filter_shape=(20, 1, 5, 5),
+                              poolsize=(2, 2),
                               activation_fn=ReLU),
-                ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12), 
-                              filter_shape=(40, 20, 5, 5), 
-                              poolsize=(2, 2), 
+                ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12),
+                              filter_shape=(40, 20, 5, 5),
+                              poolsize=(2, 2),
                               activation_fn=ReLU),
                 FullyConnectedLayer(n_in=40*4*4, n_out=100, activation_fn=ReLU),
                 SoftmaxLayer(n_in=100, n_out=10)], mini_batch_size)
@@ -130,19 +130,19 @@ def expanded_data(n=100):
     for j in range(3):
         print "Training with expanded data, %s neurons in the FC layer, run num %s" % (n, j)
         net = Network([
-            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                          filter_shape=(20, 1, 5, 5), 
-                          poolsize=(2, 2), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                          filter_shape=(20, 1, 5, 5),
+                          poolsize=(2, 2),
                           activation_fn=ReLU),
-            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12), 
-                          filter_shape=(40, 20, 5, 5), 
-                          poolsize=(2, 2), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12),
+                          filter_shape=(40, 20, 5, 5),
+                          poolsize=(2, 2),
                           activation_fn=ReLU),
             FullyConnectedLayer(n_in=40*4*4, n_out=n, activation_fn=ReLU),
             SoftmaxLayer(n_in=n, n_out=10)], mini_batch_size)
-        net.SGD(expanded_training_data, 60, mini_batch_size, 0.03, 
+        net.SGD(expanded_training_data, 60, mini_batch_size, 0.03,
                 validation_data, test_data, lmbda=0.1)
-    return net 
+    return net
 
 def expanded_data_double_fc(n=100):
     """n is the number of neurons in both fully-connected layers.  We'll
@@ -154,18 +154,18 @@ def expanded_data_double_fc(n=100):
     for j in range(3):
         print "Training with expanded data, %s neurons in two FC layers, run num %s" % (n, j)
         net = Network([
-            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                          filter_shape=(20, 1, 5, 5), 
-                          poolsize=(2, 2), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                          filter_shape=(20, 1, 5, 5),
+                          poolsize=(2, 2),
                           activation_fn=ReLU),
-            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12), 
-                          filter_shape=(40, 20, 5, 5), 
-                          poolsize=(2, 2), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12),
+                          filter_shape=(40, 20, 5, 5),
+                          poolsize=(2, 2),
                           activation_fn=ReLU),
             FullyConnectedLayer(n_in=40*4*4, n_out=n, activation_fn=ReLU),
             FullyConnectedLayer(n_in=n, n_out=n, activation_fn=ReLU),
             SoftmaxLayer(n_in=n, n_out=10)], mini_batch_size)
-        net.SGD(expanded_training_data, 60, mini_batch_size, 0.03, 
+        net.SGD(expanded_training_data, 60, mini_batch_size, 0.03,
                 validation_data, test_data, lmbda=0.1)
 
 def double_fc_dropout(p0, p1, p2, repetitions):
@@ -176,25 +176,25 @@ def double_fc_dropout(p0, p1, p2, repetitions):
         print "\n\nTraining using a dropout network with parameters ",p0,p1,p2
         print "Training with expanded data, run num %s" % j
         net = Network([
-            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28), 
-                          filter_shape=(20, 1, 5, 5), 
-                          poolsize=(2, 2), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 1, 28, 28),
+                          filter_shape=(20, 1, 5, 5),
+                          poolsize=(2, 2),
                           activation_fn=ReLU),
-            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12), 
-                          filter_shape=(40, 20, 5, 5), 
-                          poolsize=(2, 2), 
+            ConvPoolLayer(image_shape=(mini_batch_size, 20, 12, 12),
+                          filter_shape=(40, 20, 5, 5),
+                          poolsize=(2, 2),
                           activation_fn=ReLU),
             FullyConnectedLayer(
                 n_in=40*4*4, n_out=1000, activation_fn=ReLU, p_dropout=p0),
             FullyConnectedLayer(
                 n_in=1000, n_out=1000, activation_fn=ReLU, p_dropout=p1),
             SoftmaxLayer(n_in=1000, n_out=10, p_dropout=p2)], mini_batch_size)
-        net.SGD(expanded_training_data, 40, mini_batch_size, 0.03, 
+        net.SGD(expanded_training_data, 40, mini_batch_size, 0.03,
                 validation_data, test_data)
         nets.append(net)
     return nets
 
-def ensemble(nets): 
+def ensemble(nets):
     """Takes as input a list of nets, and then computes the accuracy on
     the test data when classifications are computed by taking a vote
     amongst the nets.  Returns a tuple containing a list of indices
@@ -206,24 +206,24 @@ def ensemble(nets):
     this works.
 
     """
-    
+
     test_x, test_y = test_data
     for net in nets:
         i = T.lscalar() # mini-batch index
         net.test_mb_predictions = theano.function(
             [i], net.layers[-1].y_out,
             givens={
-                net.x: 
+                net.x:
                 test_x[i*net.mini_batch_size: (i+1)*net.mini_batch_size]
             })
         net.test_predictions = list(np.concatenate(
             [net.test_mb_predictions(i) for i in xrange(1000)]))
     all_test_predictions = zip(*[net.test_predictions for net in nets])
     def plurality(p): return Counter(p).most_common(1)[0][0]
-    plurality_test_predictions = [plurality(p) 
+    plurality_test_predictions = [plurality(p)
                                   for p in all_test_predictions]
     test_y_eval = test_y.eval()
-    error_locations = [j for j in xrange(10000) 
+    error_locations = [j for j in xrange(10000)
                        if plurality_test_predictions[j] != test_y_eval[j]]
     erroneous_predictions = [plurality(all_test_predictions[j])
                              for j in error_locations]
@@ -245,7 +245,7 @@ def plot_errors(error_locations, erroneous_predictions=None):
         plt.yticks(np.array([]))
     plt.tight_layout()
     return plt
-    
+
 def plot_filters(net, layer, x, y):
 
     """Plot the filters for net after the (convolutional) layer number
@@ -281,7 +281,7 @@ def run_experiments():
     expanded_data(n=100)
     expanded_data(n=300)
     expanded_data(n=1000)
-    expanded_data_double_fc(n=100)    
+    expanded_data_double_fc(n=100)
     expanded_data_double_fc(n=300)
     expanded_data_double_fc(n=1000)
     nets = double_fc_dropout(0.5, 0.5, 0.5, 5)

--- a/src/expand_mnist.py
+++ b/src/expand_mnist.py
@@ -47,9 +47,9 @@ else:
                 (1,  1, "last",  0),
                 (-1, 1, "last",  27)]:
             new_img = np.roll(image, d, axis)
-            if index_position == "first": 
+            if index_position == "first":
                 new_img[index, :] = np.zeros(28)
-            else: 
+            else:
                 new_img[:, index] = np.zeros(28)
             expanded_training_pairs.append((np.reshape(new_img, 784), y))
     random.shuffle(expanded_training_pairs)

--- a/src/mnist_svm.py
+++ b/src/mnist_svm.py
@@ -7,7 +7,7 @@ data set, using an SVM classifier."""
 
 #### Libraries
 # My libraries
-import mnist_loader 
+import mnist_loader
 
 # Third-party libraries
 from sklearn import svm
@@ -25,4 +25,3 @@ def svm_baseline():
 
 if __name__ == "__main__":
     svm_baseline()
-    


### PR DESCRIPTION
Just to keep code clean and easier to read on editors with plugins such as [vim-trailing-whitespace](https://github.com/bronson/vim-trailing-whitespace).