### PR TITLE
Mini-Batches Fix

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -52,7 +52,7 @@ class Network(object):
         epoch, and partial progress printed out.  This is useful for
         tracking progress, but slows things down substantially."""
         if test_data: n_test = len(test_data)
-        n = len(training_data)
+        n = len(training_data[0])
         for j in xrange(epochs):
             random.shuffle(training_data)
             mini_batches = [


### PR DESCRIPTION
- n will always equal to 2
- so mini-batches will always have one batch of size 50K
- changing to this we will have 10 mini-batches of size 5K each as intended in the book